### PR TITLE
drafting agent with TipTap editor

### DIFF
--- a/app/api/case/[caseId]/draft-chat/route.ts
+++ b/app/api/case/[caseId]/draft-chat/route.ts
@@ -1,0 +1,183 @@
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { runDraftingAgent } from "@/lib/drafting-agent";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ caseId: string }> },
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const { caseId } = await params;
+
+  const caseRecord = await db.case.findUnique({
+    where: { id: caseId },
+  });
+
+  if (!caseRecord || caseRecord.userId !== session.user.id) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const body = await request.json();
+  const {
+    messages = [],
+    documentId,
+    documentName,
+    category,
+    recommenderId,
+  } = body;
+
+  let docId = documentId as string | undefined;
+  let docName = documentName as string | undefined;
+  let existingContent: string | null = null;
+
+  // If no documentId, create a new document
+  if (!docId) {
+    const doc = await db.document.create({
+      data: {
+        caseId,
+        name: docName || "Untitled Document",
+        type: "MARKDOWN",
+        source: "SYSTEM_GENERATED",
+        content: "",
+        status: "DRAFT",
+        category: category || null,
+        recommenderId: recommenderId || null,
+      },
+    });
+    docId = doc.id;
+    docName = doc.name;
+  } else {
+    // Load existing document
+    const doc = await db.document.findFirst({
+      where: { id: docId, caseId },
+    });
+    if (doc) {
+      existingContent = doc.content;
+      docName = docName || doc.name;
+    }
+  }
+
+  // Save user message
+  const lastUserMsg = messages.findLast(
+    (m: { role: string }) => m.role === "user",
+  );
+  if (lastUserMsg) {
+    await db.chatMessage.create({
+      data: {
+        caseId,
+        role: "USER",
+        content: lastUserMsg.content,
+        phase: "DRAFTING",
+        documentId: docId,
+      },
+    });
+  }
+
+  // Load drafting chat history for this document
+  const dbMessages = await db.chatMessage.findMany({
+    where: { caseId, phase: "DRAFTING", documentId: docId },
+    orderBy: { createdAt: "asc" },
+    take: 50,
+  });
+
+  const historyMessages = dbMessages.map(
+    (m: { role: string; content: string }) => ({
+      role: m.role.toLowerCase() as "user" | "assistant",
+      content: m.content,
+    }),
+  );
+
+  const agentMessages =
+    historyMessages.length > 0 ? historyMessages : messages;
+
+  const result = await runDraftingAgent({
+    caseId,
+    messages: agentMessages,
+    documentId: docId,
+    documentName: docName,
+    existingContent,
+    onFinish: async (text) => {
+      if (text) {
+        // Save assistant message
+        await db.chatMessage.create({
+          data: {
+            caseId,
+            role: "ASSISTANT",
+            content: text,
+            phase: "DRAFTING",
+            documentId: docId,
+          },
+        });
+
+        // Save generated content to document
+        if (docId) {
+          await db.document.update({
+            where: { id: docId },
+            data: { content: text },
+          });
+        }
+      }
+    },
+  });
+
+  const headers = new Headers();
+  if (docId) {
+    headers.set("X-Document-Id", docId);
+  }
+
+  const streamResponse = result.toTextStreamResponse();
+  // Copy stream body into new response with custom headers
+  return new Response(streamResponse.body, {
+    status: streamResponse.status,
+    headers: {
+      ...Object.fromEntries(streamResponse.headers.entries()),
+      "X-Document-Id": docId || "",
+    },
+  });
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ caseId: string }> },
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const { caseId } = await params;
+
+  const caseRecord = await db.case.findUnique({
+    where: { id: caseId },
+  });
+
+  if (!caseRecord || caseRecord.userId !== session.user.id) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const url = new URL(request.url);
+  const documentId = url.searchParams.get("documentId");
+
+  if (!documentId) {
+    return Response.json({ messages: [] });
+  }
+
+  const messages = await db.chatMessage.findMany({
+    where: { caseId, phase: "DRAFTING", documentId },
+    orderBy: { createdAt: "asc" },
+    take: 50,
+  });
+
+  return Response.json({
+    messages: messages.map((m) => ({
+      id: m.id,
+      role: m.role.toLowerCase(),
+      content: m.content,
+      createdAt: m.createdAt,
+    })),
+  });
+}

--- a/app/case/[caseId]/client.tsx
+++ b/app/case/[caseId]/client.tsx
@@ -7,6 +7,7 @@ import { PhaseTabs } from './_components/phase-tabs'
 import { EvidenceChatPanel } from './_components/evidence-chat-panel'
 import { DocumentChatPanel } from './_components/document-chat-panel'
 import { DocumentsPanel } from './_components/documents-panel'
+import { DraftingPanel } from './_components/drafting-panel'
 import { IntakeSheet } from './_components/intake-sheet'
 import { Upload, MessageSquare, X } from 'lucide-react'
 import type { IntakeData } from './_lib/intake-schema'
@@ -73,9 +74,20 @@ export function CasePageClient({
   const [badgeDismissed, setBadgeDismissed] = useState(false)
   const [isEvidenceLoading, setIsEvidenceLoading] = useState(false)
   const [isDocumentLoading, setIsDocumentLoading] = useState(false)
+  const [draftingDoc, setDraftingDoc] = useState<{
+    id?: string
+    name?: string
+    content?: string
+    recommenderId?: string
+    category?: string
+  } | null>(null)
   const [intakeOpen, setIntakeOpen] = useState(initialIntakeStatus === 'PENDING')
   const [chatOpen, setChatOpen] = useState(true)
   const initiatedRef = useRef(false)
+
+  const onOpenDraft = useCallback((doc?: { id?: string; name?: string; content?: string; recommenderId?: string; category?: string }) => {
+    setDraftingDoc(doc || {})
+  }, [])
 
   const showEvidenceBadge = activeTab === 'analysis' && strongCount >= threshold && !badgeDismissed
 
@@ -349,8 +361,16 @@ export function CasePageClient({
         )}
       </div>
 
-      {/* Tab content */}
-      {activeTab === 'analysis' ? (
+      {/* Drafting panel overlay */}
+      {draftingDoc !== null ? (
+        <DraftingPanel
+          caseId={caseId}
+          document={draftingDoc}
+          onClose={() => setDraftingDoc(null)}
+          onSave={() => setDraftingDoc(null)}
+        />
+      ) : /* Tab content */
+      activeTab === 'analysis' ? (
         <div className="flex flex-1 overflow-hidden relative">
           <input
             ref={fileInputRef}
@@ -412,7 +432,7 @@ export function CasePageClient({
         <div className="flex flex-1 overflow-hidden relative">
           {/* Documents Panel - fills remaining space */}
           <div className="flex-1 bg-muted/50 overflow-hidden">
-            <DocumentsPanel caseId={caseId} isChatActive={isEvidenceLoading} />
+            <DocumentsPanel caseId={caseId} isChatActive={isEvidenceLoading} onOpenDraft={onOpenDraft} />
           </div>
 
           {/* Evidence Chat - right side, closable */}
@@ -447,7 +467,7 @@ export function CasePageClient({
         <div className="flex flex-1 overflow-hidden relative">
           {/* Documents Panel */}
           <div className="flex-1 bg-muted/50 overflow-hidden">
-            <DocumentsPanel caseId={caseId} isChatActive={isDocumentLoading} hideChecklists />
+            <DocumentsPanel caseId={caseId} isChatActive={isDocumentLoading} hideChecklists onOpenDraft={onOpenDraft} />
           </div>
 
           {/* Document Chat - right side, closable */}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -78,6 +78,7 @@ enum ChatPhase {
   ANALYSIS
   EVIDENCE
   DOCUMENTS
+  DRAFTING
 }
 
 enum IntakeStatus {
@@ -180,17 +181,19 @@ enum ChatRole {
 }
 
 model ChatMessage {
-  id        String    @id @default(cuid())
-  caseId    String
-  role      ChatRole
-  content   String
-  metadata  Json?
-  phase     ChatPhase @default(ANALYSIS)
-  createdAt DateTime  @default(now())
+  id         String    @id @default(cuid())
+  caseId     String
+  role       ChatRole
+  content    String
+  metadata   Json?
+  phase      ChatPhase @default(ANALYSIS)
+  documentId String?
+  createdAt  DateTime  @default(now())
 
   case Case @relation(fields: [caseId], references: [id], onDelete: Cascade)
 
   @@index([caseId, createdAt])
+  @@index([caseId, documentId])
 }
 
 model ResumeUpload {


### PR DESCRIPTION
## Summary
- Drafting agent (ToolLoopAgent) with context-gathering tools, outputs document content as streamed text
- draft-chat API route: POST streams agent output + creates/updates documents, GET returns per-document chat history
- DraftingPanel: 2-column layout (chat instructions left 1/4, TiptapEditor right 3/4)
- TiptapEditor: streaming prop (disables editing during generation), onSave prop (Cmd+S)
- Draft/New Document buttons wired into documents panel and case page

## Test plan
- [ ] Click "New Document" in vault, drafting panel opens with empty editor + chat
- [ ] Type instruction, content streams into editor
- [ ] Type revision instruction, editor updates with revised content
- [ ] Manual edit in editor, Save persists
- [ ] Close panel, document appears in vault
- [ ] Click Draft icon on existing doc, loads previous chat history + content