### PR TITLE
sensible case names + display everywhere

### DIFF
--- a/app/case/[caseId]/layout.tsx
+++ b/app/case/[caseId]/layout.tsx
@@ -5,12 +5,27 @@ import {
   SidebarTrigger,
 } from '@/components/ui/sidebar'
 import { Separator } from '@/components/ui/separator'
+import { db } from '@/lib/db'
 
-export default function CaseLayout({
+export default async function CaseLayout({
   children,
+  params,
 }: {
   children: React.ReactNode
+  params: Promise<{ caseId: string }>
 }) {
+  const { caseId } = await params
+  const caseRecord = await db.case.findUnique({
+    where: { id: caseId },
+    select: { name: true, createdAt: true },
+  })
+
+  const displayName = caseRecord?.name || "Case Builder"
+  const dateStr = caseRecord?.createdAt
+    ? new Date(caseRecord.createdAt).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })
+      + " " + new Date(caseRecord.createdAt).toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" })
+    : null
+
   return (
     <SidebarProvider className="h-svh overflow-hidden">
       <AppSidebar />
@@ -22,9 +37,14 @@ export default function CaseLayout({
               orientation="vertical"
               className="mr-2 data-[orientation=vertical]:h-4"
             />
-            <span className="text-sm font-medium text-stone-600 dark:text-stone-400">
-              Case Builder
-            </span>
+            <div className="grid text-left leading-tight">
+              <span className="text-sm font-medium text-stone-600 dark:text-stone-400">
+                {displayName}
+              </span>
+              {dateStr && (
+                <span className="text-xs text-muted-foreground">{dateStr}</span>
+              )}
+            </div>
           </div>
         </header>
         {children}

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -64,6 +64,12 @@ interface CaseItem {
   createdAt: string
 }
 
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr)
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })
+    + " " + d.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" })
+}
+
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const { data: session } = useSession()
   const pathname = usePathname()
@@ -183,13 +189,17 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                     <SidebarMenuItem>
                       <SidebarMenuButton
                         asChild
+                        size="lg"
                         isActive={c.id === currentCaseId}
                       >
                         <Link href={`/case/${c.id}`}>
                           <FolderOpen className="size-4" />
-                          <span className="truncate">
-                            {getCaseName(c)}
-                          </span>
+                          <div className="grid flex-1 text-left leading-tight min-w-0">
+                            <span className="truncate text-sm">{getCaseName(c)}</span>
+                            <span className="truncate text-xs text-muted-foreground">
+                              {formatDate(c.createdAt)}
+                            </span>
+                          </div>
                         </Link>
                       </SidebarMenuButton>
                     </SidebarMenuItem>


### PR DESCRIPTION
## Summary
- Generate meaningful case names from survey data (name + visa category) in extract route
- Display case name + date in sidebar with lg spacing
- Async layout with dynamic name/date header on case page
- caseName state + display on onboard page

## Test plan
- [ ] Create new case via onboard flow, verify case gets sensible name
- [ ] Check sidebar shows case name with date subtitle
- [ ] Check case page header shows name + date