### PR TITLE
fix admin page build prerender

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 import { db } from '@/lib/db'
 import { FolderOpen, ListChecks, FileStack, MessageSquare } from 'lucide-react'
 


### PR DESCRIPTION
## Summary
- Add `force-dynamic` to `/admin` page to prevent static prerendering during build (DB unreachable at build time)

## Test plan
- Verify Vercel build passes without `ENETUNREACH` error