### PR TITLE
prisma datasource: pooler + direct URL for supabase

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,7 +3,9 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
 }
 
 // NextAuth required models


### PR DESCRIPTION
## Summary
- Add explicit `url` (pooler, port 6543) and `directUrl` (port 5432) to Prisma datasource
- Fixes `P1001 Can't reach database server` on Vercel serverless

## Test plan
- Verify Vercel build + runtime DB queries succeed