### PR TITLE
fix prisma 7 datasource config for supabase

### DIFF
--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -6,5 +6,6 @@ export default defineConfig({
   schema: path.join(__dirname, 'prisma', 'schema.prisma'),
   datasource: {
     url: process.env.DATABASE_URL!,
+    directUrl: process.env.DIRECT_URL,
   },
 })

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,9 +3,7 @@ generator client {
 }
 
 datasource db {
-  provider  = "postgresql"
-  url       = env("DATABASE_URL")
-  directUrl = env("DIRECT_URL")
+  provider = "postgresql"
 }
 
 // NextAuth required models


### PR DESCRIPTION
## Summary
- Revert `url`/`directUrl` from schema (unsupported in Prisma 7)
- Add `directUrl` to `prisma.config.ts` instead

## Test plan
- Verify build passes, DB reachable on Vercel