### PR TITLE
remove directUrl from prisma config

### DIFF
--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -6,6 +6,5 @@ export default defineConfig({
   schema: path.join(__dirname, 'prisma', 'schema.prisma'),
   datasource: {
     url: process.env.DATABASE_URL!,
-    directUrl: process.env.DIRECT_URL,
   },
 })


### PR DESCRIPTION
Use pooler URL on Vercel, direct URL locally -- both via DATABASE_URL.