### PR TITLE
push to evidence, evidence preview, auto re-analysis

### DIFF
--- a/app/api/case/[caseId]/criteria-routing/route.ts
+++ b/app/api/case/[caseId]/criteria-routing/route.ts
@@ -27,7 +27,7 @@ export async function GET(
     where: { document: { caseId } },
     include: {
       document: {
-        select: { id: true, name: true, category: true },
+        select: { id: true, name: true, category: true, type: true },
       },
     },
     orderBy: { criterion: "asc" },
@@ -41,6 +41,7 @@ export async function GET(
       documentId: string
       name: string
       category: string | null
+      type: string
       score: number
       recommendation: string
       autoRouted: boolean
@@ -56,6 +57,7 @@ export async function GET(
       documentId: r.document.id,
       name: r.document.name,
       category: r.document.category,
+      type: r.document.type,
       score: r.score,
       recommendation: r.recommendation,
       autoRouted: r.autoRouted,

--- a/app/api/webhooks/docuseal/route.ts
+++ b/app/api/webhooks/docuseal/route.ts
@@ -108,6 +108,21 @@ export async function POST(request: Request) {
               where: { id: sigReq.id },
               data: { signedDocumentS3Key: s3Key, signedDocumentS3Url: url },
             })
+
+            // Copy criterion routings from original doc to signed doc
+            const routings = await db.documentCriterionRouting.findMany({
+              where: { documentId: sigReq.documentId },
+            })
+            if (routings.length > 0) {
+              await db.documentCriterionRouting.createMany({
+                data: routings.map((r) => ({
+                  documentId: signedDoc.id,
+                  criterion: r.criterion,
+                  score: r.score,
+                  recommendation: r.recommendation,
+                })),
+              })
+            }
           }
         }
         break

--- a/app/case/[caseId]/_components/drafting-panel.tsx
+++ b/app/case/[caseId]/_components/drafting-panel.tsx
@@ -6,7 +6,7 @@ import { TiptapEditor } from '@/components/ui/tiptap-editor'
 import { ChatInput } from '@/components/ui/chat-input'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Button } from '@/components/ui/button'
-import { ArrowLeft, Save, Loader2, ChevronDown, CircleCheck, CheckCircle2, PenTool } from 'lucide-react'
+import { ArrowLeft, Save, Loader2, ChevronDown, CircleCheck, CheckCircle2, PenTool, FileSignature } from 'lucide-react'
 import { SignRequestDialog } from './sign-request-dialog'
 import { SigningView } from './signing-view'
 import {
@@ -60,6 +60,7 @@ export function DraftingPanel({
   const [docType, setDocType] = useState<string>('MARKDOWN')
   const [signDialogOpen, setSignDialogOpen] = useState(false)
   const [signingViewOpen, setSigningViewOpen] = useState(false)
+  const [selfSigning, setSelfSigning] = useState(false)
   const [isLoadingHistory, setIsLoadingHistory] = useState(false)
   const chatEndRef = useRef<HTMLDivElement>(null)
   const editorContentRef = useRef(editorContent)
@@ -278,15 +279,41 @@ export function DraftingPanel({
         </div>
         <div className="flex items-center gap-1 shrink-0">
           {docId && docStatus === 'FINAL' && (
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-7 text-xs gap-1"
-              onClick={() => setSignDialogOpen(true)}
-            >
-              <PenTool className="w-3.5 h-3.5" />
-              E-Sign
-            </Button>
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 text-xs gap-1"
+                disabled={selfSigning}
+                onClick={async () => {
+                  if (!docId) return
+                  setSelfSigning(true)
+                  try {
+                    const res = await fetch(`/api/case/${caseId}/documents/${docId}/sign`, {
+                      method: 'POST',
+                      headers: { 'Content-Type': 'application/json' },
+                      body: JSON.stringify({ selfSign: true }),
+                    })
+                    if (res.ok) {
+                      setSigningViewOpen(true)
+                    }
+                  } catch { /* ignore */ }
+                  finally { setSelfSigning(false) }
+                }}
+              >
+                {selfSigning ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <FileSignature className="w-3.5 h-3.5" />}
+                Sign Now
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 text-xs gap-1"
+                onClick={() => setSignDialogOpen(true)}
+              >
+                <PenTool className="w-3.5 h-3.5" />
+                E-Sign
+              </Button>
+            </>
           )}
           {docId && (
             <Button
@@ -471,6 +498,8 @@ export function DraftingPanel({
           caseId={caseId}
           docId={docId}
           docName={docName}
+          currentUserEmail={session?.user?.email ?? undefined}
+          currentUserName={session?.user?.name ?? undefined}
           onSuccess={() => {
             setSignDialogOpen(false)
             setSigningViewOpen(true)

--- a/app/case/[caseId]/_components/drafting-panel.tsx
+++ b/app/case/[caseId]/_components/drafting-panel.tsx
@@ -509,7 +509,7 @@ export function DraftingPanel({
 
       {signingViewOpen && docId && (
         <Dialog open={signingViewOpen} onOpenChange={setSigningViewOpen}>
-          <DialogContent className="sm:max-w-lg max-h-[80vh] p-0 overflow-hidden">
+          <DialogContent className="sm:max-w-2xl h-[90vh] p-0 overflow-hidden flex flex-col">
             <SigningView
               caseId={caseId}
               docId={docId}

--- a/app/case/[caseId]/_components/letters-panel.tsx
+++ b/app/case/[caseId]/_components/letters-panel.tsx
@@ -47,7 +47,10 @@ import type { SurveyIntent } from '@/app/onboard/_lib/survey-schema'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Checkbox } from '@/components/ui/checkbox'
+import { useSession } from 'next-auth/react'
 import { RecommenderForm } from './recommender-form'
+import { SignRequestDialog } from './sign-request-dialog'
+import { SigningView } from './signing-view'
 import type { RecommenderData } from './recommender-form'
 import { CsvImportModal } from './csv-import-modal'
 import type { DenialProbability } from '@/lib/denial-probability-schema'
@@ -398,11 +401,15 @@ function UploadOnlyCard({
   docs,
   caseId,
   onUploaded,
+  onSignNow,
+  onRequestSign,
 }: {
   letterType: LetterType
   docs: DocumentItem[]
   caseId: string
   onUploaded: () => void
+  onSignNow?: (docId: string, docName: string) => void
+  onRequestSign?: (docId: string, docName: string) => void
 }) {
   const Icon = letterType.icon
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -518,22 +525,36 @@ function UploadOnlyCard({
               e.target.value = ''
             }}
           />
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span tabIndex={0} onClick={(e) => e.stopPropagation()}>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-7 text-[11px] gap-1 cursor-not-allowed opacity-50"
-                  disabled
-                >
-                  <PenTool className="w-3 h-3" />
-                  E-Sign
-                </Button>
-              </span>
-            </TooltipTrigger>
-            <TooltipContent>Coming soon</TooltipContent>
-          </Tooltip>
+          {(() => {
+            const finalDocs = docs.filter((d) => d.status === 'FINAL')
+            if (finalDocs.length === 0) return null
+            return (
+              <>
+                {onSignNow && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 text-[11px] gap-1"
+                    onClick={(e) => { e.stopPropagation(); onSignNow(finalDocs[0].id, finalDocs[0].name) }}
+                  >
+                    <PenTool className="w-3 h-3" />
+                    Sign Now
+                  </Button>
+                )}
+                {onRequestSign && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 text-[11px] gap-1"
+                    onClick={(e) => { e.stopPropagation(); onRequestSign(finalDocs[0].id, finalDocs[0].name) }}
+                  >
+                    <PenTool className="w-3 h-3" />
+                    E-Sign
+                  </Button>
+                )}
+              </>
+            )
+          })()}
           {docs.length > 0 && (
             <ChevronDown
               className={cn(
@@ -583,6 +604,8 @@ export function RecommenderCard({
   onImportCsv,
   onUploaded,
   onShare,
+  onSignNow,
+  onRequestSign,
 }: {
   letterType: LetterType
   recommenders: Recommender[]
@@ -594,6 +617,8 @@ export function RecommenderCard({
   onImportCsv: () => void
   onUploaded: () => void
   onShare?: (docId: string, docName: string) => void
+  onSignNow?: (docId: string, docName: string) => void
+  onRequestSign?: (docId: string, docName: string) => void
 }) {
   const Icon = letterType.icon
   const hasContent = recommenders.length > 0 || allRecDocs.length > 0
@@ -817,22 +842,36 @@ export function RecommenderCard({
               e.target.value = ''
             }}
           />
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span tabIndex={0} onClick={(e) => e.stopPropagation()}>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-7 text-[11px] gap-1 cursor-not-allowed opacity-50"
-                  disabled
-                >
-                  <PenTool className="w-3 h-3" />
-                  E-Sign
-                </Button>
-              </span>
-            </TooltipTrigger>
-            <TooltipContent>Coming soon</TooltipContent>
-          </Tooltip>
+          {(() => {
+            const finalRecDocs = allRecDocs.filter((d) => d.status === 'FINAL')
+            if (finalRecDocs.length === 0) return null
+            return (
+              <>
+                {onSignNow && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 text-[11px] gap-1"
+                    onClick={(e) => { e.stopPropagation(); onSignNow(finalRecDocs[0].id, finalRecDocs[0].name) }}
+                  >
+                    <PenTool className="w-3 h-3" />
+                    Sign Now
+                  </Button>
+                )}
+                {onRequestSign && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 text-[11px] gap-1"
+                    onClick={(e) => { e.stopPropagation(); onRequestSign(finalRecDocs[0].id, finalRecDocs[0].name) }}
+                  >
+                    <PenTool className="w-3 h-3" />
+                    E-Sign
+                  </Button>
+                )}
+              </>
+            )
+          })()}
           {hasContent && (
             <ChevronDown
               className={cn(
@@ -1128,6 +1167,8 @@ function DraftableCard({
   onOpenDraft,
   onUploaded,
   onShare,
+  onSignNow,
+  onRequestSign,
 }: {
   letterType: LetterType
   docs: DocumentItem[]
@@ -1135,6 +1176,8 @@ function DraftableCard({
   onOpenDraft: LettersPanelProps['onOpenDraft']
   onUploaded: () => void
   onShare?: (docId: string, docName: string) => void
+  onSignNow?: (docId: string, docName: string) => void
+  onRequestSign?: (docId: string, docName: string) => void
 }) {
   const Icon = letterType.icon
   const [expanded, setExpanded] = useState(false)
@@ -1253,22 +1296,36 @@ function DraftableCard({
               e.target.value = ''
             }}
           />
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span tabIndex={0} onClick={(e) => e.stopPropagation()}>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-7 text-[11px] gap-1 cursor-not-allowed opacity-50"
-                  disabled
-                >
-                  <PenTool className="w-3 h-3" />
-                  E-Sign
-                </Button>
-              </span>
-            </TooltipTrigger>
-            <TooltipContent>Coming soon</TooltipContent>
-          </Tooltip>
+          {(() => {
+            const finalDocs = docs.filter((d) => d.status === 'FINAL')
+            if (finalDocs.length === 0) return null
+            return (
+              <>
+                {onSignNow && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 text-[11px] gap-1"
+                    onClick={(e) => { e.stopPropagation(); onSignNow(finalDocs[0].id, finalDocs[0].name) }}
+                  >
+                    <PenTool className="w-3 h-3" />
+                    Sign Now
+                  </Button>
+                )}
+                {onRequestSign && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 text-[11px] gap-1"
+                    onClick={(e) => { e.stopPropagation(); onRequestSign(finalDocs[0].id, finalDocs[0].name) }}
+                  >
+                    <PenTool className="w-3 h-3" />
+                    E-Sign
+                  </Button>
+                )}
+              </>
+            )
+          })()}
           {docs.length > 0 && (
             <ChevronDown
               className={cn(
@@ -1566,12 +1623,16 @@ function UsIntentCard({ caseId, initialData }: { caseId: string; initialData?: S
 }
 
 export function LettersPanel({ caseId, onOpenDraft, denialProbability, initialIntentData }: LettersPanelProps) {
+  const { data: session } = useSession()
   const [documents, setDocuments] = useState<DocumentItem[]>([])
   const [recommenders, setRecommenders] = useState<Recommender[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [showAddRecommender, setShowAddRecommender] = useState(false)
   const [showCsvImport, setShowCsvImport] = useState(false)
   const [assembling, setAssembling] = useState(false)
+  // Signing state
+  const [signTarget, setSignTarget] = useState<{ docId: string; docName: string } | null>(null)
+  const [signingViewTarget, setSigningViewTarget] = useState<{ docId: string; docName: string } | null>(null)
   const [globalDragOver, setGlobalDragOver] = useState(false)
   const [globalUploading, setGlobalUploading] = useState(false)
   const [categoryPicker, setCategoryPicker] = useState<{
@@ -1613,6 +1674,24 @@ export function LettersPanel({ caseId, onOpenDraft, denialProbability, initialIn
     setShowAddRecommender(false)
     fetchData()
   }, [fetchData])
+
+  const handleSignNow = useCallback(async (docId: string, docName: string) => {
+    try {
+      const res = await fetch(`/api/case/${caseId}/documents/${docId}/sign`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ selfSign: true }),
+      })
+      if (res.ok) {
+        setSigningViewTarget({ docId, docName })
+      } else {
+        const data = await res.json().catch(() => ({}))
+        toast.error(data.error || 'Failed to create self-sign request')
+      }
+    } catch {
+      toast.error('Failed to create self-sign request')
+    }
+  }, [caseId])
 
   const handleAssemblePackage = useCallback(async () => {
     setAssembling(true)
@@ -1810,6 +1889,8 @@ export function LettersPanel({ caseId, onOpenDraft, denialProbability, initialIn
                 docs={docs}
                 caseId={caseId}
                 onUploaded={fetchData}
+                onSignNow={handleSignNow}
+                onRequestSign={(docId, docName) => setSignTarget({ docId, docName })}
               />
             )
           }
@@ -1824,6 +1905,8 @@ export function LettersPanel({ caseId, onOpenDraft, denialProbability, initialIn
               onOpenDraft={onOpenDraft}
               onUploaded={fetchData}
               onShare={(docId, docName) => setShareTarget({ docId, docName })}
+              onSignNow={handleSignNow}
+              onRequestSign={(docId, docName) => setSignTarget({ docId, docName })}
             />
           )
         })}
@@ -1888,6 +1971,40 @@ export function LettersPanel({ caseId, onOpenDraft, denialProbability, initialIn
         docId={shareTarget.docId}
         docName={shareTarget.docName}
       />
+    )}
+
+    {signTarget && (
+      <SignRequestDialog
+        open={!!signTarget}
+        onOpenChange={(open) => { if (!open) setSignTarget(null) }}
+        caseId={caseId}
+        docId={signTarget.docId}
+        docName={signTarget.docName}
+        currentUserEmail={session?.user?.email ?? undefined}
+        currentUserName={session?.user?.name ?? undefined}
+        onSuccess={() => {
+          const target = signTarget
+          setSignTarget(null)
+          if (target) setSigningViewTarget(target)
+          fetchData()
+        }}
+      />
+    )}
+
+    {signingViewTarget && (
+      <Dialog open={!!signingViewTarget} onOpenChange={(open) => { if (!open) { setSigningViewTarget(null); fetchData() } }}>
+        <DialogContent className="sm:max-w-lg max-h-[80vh] p-0 overflow-hidden">
+          <DialogTitle className="sr-only">Sign Document</DialogTitle>
+          <SigningView
+            caseId={caseId}
+            docId={signingViewTarget.docId}
+            docName={signingViewTarget.docName}
+            currentUserEmail={session?.user?.email ?? undefined}
+            onClose={() => { setSigningViewTarget(null); fetchData() }}
+            onSignComplete={fetchData}
+          />
+        </DialogContent>
+      </Dialog>
     )}
     </>
     </TooltipProvider>

--- a/app/case/[caseId]/_components/letters-panel.tsx
+++ b/app/case/[caseId]/_components/letters-panel.tsx
@@ -1993,7 +1993,7 @@ export function LettersPanel({ caseId, onOpenDraft, denialProbability, initialIn
 
     {signingViewTarget && (
       <Dialog open={!!signingViewTarget} onOpenChange={(open) => { if (!open) { setSigningViewTarget(null); fetchData() } }}>
-        <DialogContent className="sm:max-w-lg max-h-[80vh] p-0 overflow-hidden">
+        <DialogContent className="sm:max-w-2xl h-[90vh] p-0 overflow-hidden flex flex-col">
           <DialogTitle className="sr-only">Sign Document</DialogTitle>
           <SigningView
             caseId={caseId}

--- a/app/case/[caseId]/_components/phase-tabs.tsx
+++ b/app/case/[caseId]/_components/phase-tabs.tsx
@@ -2,7 +2,7 @@
 
 import { cn } from '@/lib/utils'
 
-type Phase = 'analysis' | 'evidence' | 'documents' | 'package'
+type Phase = 'analysis' | 'evidence' | 'documents'
 
 interface PhaseTabsProps {
   activeTab: Phase
@@ -12,7 +12,6 @@ interface PhaseTabsProps {
 const tabs: { value: Phase; label: string; subtitle?: string }[] = [
   { value: 'analysis', label: 'Analysis' },
   { value: 'documents', label: 'Case Vault' },
-  { value: 'package', label: 'Package' },
 ]
 
 export function PhaseTabs({ activeTab, onTabChange }: PhaseTabsProps) {

--- a/app/case/[caseId]/_components/report-panel.tsx
+++ b/app/case/[caseId]/_components/report-panel.tsx
@@ -12,6 +12,7 @@ import { RecommendersPanel } from "./recommenders-panel"
 import { ConsolidationTab } from "./consolidation-tab"
 import { LettersPanel } from "./letters-panel"
 import { DenialProbabilityPanel } from "./denial-probability-panel"
+import { PackagePanel } from "./package-panel"
 import type { DetailedExtraction, CriteriaSummaryItem } from "@/lib/eb1a-extraction-schema"
 import { CRITERIA_METADATA, resolveCanonicalId } from "@/lib/eb1a-extraction-schema"
 import type { StrengthEvaluation } from "@/lib/strength-evaluation-schema"
@@ -987,7 +988,7 @@ function CriterionSection({
   )
 }
 
-type ReportTab = "summary" | "planning" | "evidence" | "routing" | "recommenders" | "consolidation" | "letters" | "denial" | "raw"
+type ReportTab = "summary" | "planning" | "evidence" | "routing" | "recommenders" | "consolidation" | "letters" | "package" | "denial" | "raw"
 
 export function ReportPanel({
   caseId,
@@ -1009,7 +1010,7 @@ export function ReportPanel({
   const router = useRouter()
   const pathname = usePathname()
 
-  const validSubTabs = useMemo(() => new Set<ReportTab>(["summary", "planning", "evidence", "recommenders", "consolidation", "letters", "denial", "raw"]), [])
+  const validSubTabs = useMemo(() => new Set<ReportTab>(["summary", "planning", "evidence", "recommenders", "consolidation", "letters", "package", "denial", "raw"]), [])
   const subtabParam = searchParams.get('subtab')
   const initialSubTab = subtabParam && validSubTabs.has(subtabParam as ReportTab)
     ? (subtabParam as ReportTab)
@@ -1321,22 +1322,6 @@ export function ReportPanel({
                   </TooltipTrigger>
                   <TooltipContent side="bottom">Uploaded documents and evidence items</TooltipContent>
                 </Tooltip>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      onClick={() => handleSubTabChange("recommenders")}
-                      className={cn(
-                        "px-3 py-1.5 text-xs font-medium rounded-md transition-colors",
-                        activeTab === "recommenders"
-                          ? "bg-primary text-primary-foreground shadow-sm"
-                          : "text-muted-foreground hover:text-foreground hover:bg-background/60"
-                      )}
-                    >
-                      Recommenders
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">Manage recommender profiles and letter assignments</TooltipContent>
-                </Tooltip>
               </div>
             </div>
 
@@ -1364,6 +1349,22 @@ export function ReportPanel({
                     </button>
                   </TooltipTrigger>
                   <TooltipContent side="bottom">Draft recommendation letters and supporting documents</TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={() => handleSubTabChange("package")}
+                      className={cn(
+                        "px-3 py-1.5 text-xs font-medium rounded-md transition-colors",
+                        activeTab === "package"
+                          ? "bg-primary text-primary-foreground shadow-sm"
+                          : "text-muted-foreground hover:text-foreground hover:bg-background/60"
+                      )}
+                    >
+                      Package
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">Assemble and manage petition package</TooltipContent>
                 </Tooltip>
                 <Tooltip>
                   <TooltipTrigger asChild>
@@ -1511,6 +1512,10 @@ export function ReportPanel({
       ) : activeTab === "letters" ? (
         <div className="flex-1 overflow-y-auto">
           <LettersPanel caseId={caseId} onOpenDraft={onOpenDraft ?? (() => {})} denialProbability={initialDenialProbability} initialIntentData={initialIntentData} />
+        </div>
+      ) : activeTab === "package" ? (
+        <div className="flex-1 overflow-hidden">
+          <PackagePanel caseId={caseId} />
         </div>
       ) : activeTab === "denial" ? (
         <DenialProbabilityPanel

--- a/app/case/[caseId]/_components/signing-view.tsx
+++ b/app/case/[caseId]/_components/signing-view.tsx
@@ -43,6 +43,7 @@ interface SigningViewProps {
   docName: string
   currentUserEmail?: string
   onClose: () => void
+  onSignComplete?: () => void
 }
 
 const SIGNER_STATUS_CONFIG: Record<
@@ -93,6 +94,7 @@ export function SigningView({
   docName,
   currentUserEmail,
   onClose,
+  onSignComplete,
 }: SigningViewProps) {
   const [requests, setRequests] = useState<SignatureRequestData[]>([])
   const [loading, setLoading] = useState(true)
@@ -196,6 +198,7 @@ export function SigningView({
             onComplete={() => {
               toast.success('Document signed')
               fetchRequests()
+              onSignComplete?.()
             }}
             onDecline={() => {
               toast.info('Signing declined')

--- a/app/case/[caseId]/client.tsx
+++ b/app/case/[caseId]/client.tsx
@@ -9,7 +9,6 @@ import { EvidenceChatPanel } from './_components/evidence-chat-panel'
 import { DocumentChatPanel } from './_components/document-chat-panel'
 import { DocumentsPanel } from './_components/documents-panel'
 import { DraftingPanel } from './_components/drafting-panel'
-import { PackagePanel } from './_components/package-panel'
 import { IntakeSheet } from './_components/intake-sheet'
 import { Upload, MessageSquare, X, ShieldAlert } from 'lucide-react'
 import {
@@ -104,10 +103,10 @@ export function CasePageClient({
   const router = useRouter()
   const pathname = usePathname()
 
-  const validTabs = useMemo(() => new Set(['analysis', 'evidence', 'documents', 'package'] as const), [])
+  const validTabs = useMemo(() => new Set(['analysis', 'evidence', 'documents'] as const), [])
   const tabParam = searchParams.get('tab')
-  const initialTab = tabParam && validTabs.has(tabParam as 'analysis' | 'evidence' | 'documents' | 'package')
-    ? (tabParam as 'analysis' | 'evidence' | 'documents' | 'package')
+  const initialTab = tabParam && validTabs.has(tabParam as 'analysis' | 'evidence' | 'documents')
+    ? (tabParam as 'analysis' | 'evidence' | 'documents')
     : 'analysis'
 
   const [messages, setMessages] = useState<Message[]>(initialMessages)
@@ -115,9 +114,19 @@ export function CasePageClient({
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [analysisVersion, setAnalysisVersion] = useState(initialAnalysisVersion)
   const [threshold, setThreshold] = useState(initialThreshold)
-  const [activeTab, setActiveTab] = useState<'analysis' | 'evidence' | 'documents' | 'package'>(initialTab)
+  const [activeTab, setActiveTab] = useState<'analysis' | 'evidence' | 'documents'>(initialTab)
 
-  const handleTabChange = useCallback((tab: 'analysis' | 'evidence' | 'documents' | 'package') => {
+  // Redirect old ?tab=package URLs to ?tab=analysis&subtab=package
+  useEffect(() => {
+    if (tabParam === 'package') {
+      const params = new URLSearchParams(searchParams.toString())
+      params.set('tab', 'analysis')
+      params.set('subtab', 'package')
+      router.replace(`${pathname}?${params.toString()}`, { scroll: false })
+    }
+  }, [tabParam, searchParams, router, pathname])
+
+  const handleTabChange = useCallback((tab: 'analysis' | 'evidence' | 'documents') => {
     setActiveTab(tab)
     const params = new URLSearchParams(searchParams.toString())
     params.set('tab', tab)
@@ -468,12 +477,6 @@ export function CasePageClient({
         <div className="flex flex-1 overflow-hidden">
           <div className="flex-1 bg-muted/50 overflow-hidden">
             <DocumentsPanel caseId={caseId} isChatActive={isEvidenceLoading} onOpenDraft={onOpenDraft} onDocumentsRouted={() => setAnalysisVersion((v) => v + 1)} />
-          </div>
-        </div>
-      ) : activeTab === 'package' ? (
-        <div className="flex flex-1 overflow-hidden">
-          <div className="flex-1 overflow-hidden">
-            <PackagePanel caseId={caseId} />
           </div>
         </div>
       ) : (

--- a/lib/docuseal.ts
+++ b/lib/docuseal.ts
@@ -93,14 +93,15 @@ async function createTemplateFromPdf(
 // Returns array of submitter objects (not a submission wrapper)
 async function createSubmission(
   templateId: number,
-  submitters: Submitter[]
+  submitters: Submitter[],
+  sendEmail = true
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<any> {
   const res = await docusealFetch('/submissions', {
     method: 'POST',
     body: JSON.stringify({
       template_id: templateId,
-      send_email: true,
+      send_email: sendEmail,
       submitters: submitters.map((s) => ({
         email: s.email,
         name: s.name,
@@ -117,12 +118,13 @@ async function createSubmission(
 export async function createSubmissionFromPdf(
   name: string,
   fileBase64: string,
-  submitters: Submitter[]
+  submitters: Submitter[],
+  sendEmail = true
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<any> {
   const roles = submitters.map((s) => s.role || 'First Party')
   const template = await createTemplateFromPdf(name, fileBase64, roles)
-  return createSubmission(template.id, submitters)
+  return createSubmission(template.id, submitters, sendEmail)
 }
 
 export async function getSubmission(


### PR DESCRIPTION
## Summary
- Signed docs can be pushed to Evidence List from SigningView and Documents panel
- Evidence List routed docs now have preview Sheet (markdown via TiptapEditor, PDF/DOCX via iframe)
- Strength eval + gap analysis auto-re-run when evidence changes (uploads, drops, push-to-evidence)

## Test plan
- [ ] Sign a doc -> open SigningView -> "Push to Evidence" appears on completed request -> click -> doc routed to evidence
- [ ] Documents panel: signed doc card shows "Push to Evidence" button -> click -> verify runs
- [ ] Evidence List: click Eye icon on routed doc -> Sheet opens with preview
- [ ] Upload evidence file -> after processing -> strength eval + gap analysis auto-run (banner visible)